### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A simple example of a smart contract system built with this library is shown und
 
 You'll need to import these contracts to your own repo to use them. You can use any of the following methods:
 - With a yarn repo (as in the example):
-  - `yarn add https://github.com/omni-network/omni-std`
+  - `yarn add omni-std@https://github.com/omni-network/omni-std`
   - Import with `@omni/contracts/{...}`
 - With forge:
     - `forge install github.com/omni-network/omni-std`


### PR DESCRIPTION
yarn ^3.2 requires package names to be explicitly specified.

Otherwise, it will throw an error:
```
Usage Error: It seems you are trying to add a package using a https:... url; we now require package names to be explicitly specified.
Try running the command again with the package name prefixed: yarn add my-package@https:...
```