### PR TITLE
Fix import path in usage docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simple examples of smart contract systems built with this library can be found a
 You'll need to import these contracts to your own repo to use them. You can use any of the following methods:
 - With yarn:
   - `yarn add @omni-network/contracts`
-  - Import with `@omni/contracts/{...}`
+  - Import with `@omni-network/contracts/contracts/{...}`
 - With forge:
     - `forge install github.com/omni-network/omni-std`
     - Import with `lib/omni-std/{...}`, or use remappings

--- a/README.md
+++ b/README.md
@@ -9,12 +9,75 @@ Simple examples of smart contract systems built with this library can be found a
 - `contracts/`: Omni solidity library implementation
 - `src/`: typescript & react utilities for interacting with Omni contracts
 
-## How to Use for your own contracts
+## Usage
 
 You'll need to import these contracts to your own repo to use them. You can use any of the following methods:
-- With yarn:
-  - `yarn add @omni-network/contracts`
-  - Import with `@omni-network/contracts/contracts/{...}`
-- With forge:
-    - `forge install github.com/omni-network/omni-std`
-    - Import with `lib/omni-std/{...}`, or use remappings
+
+
+### npm
+
+
+Install
+
+```bash
+yarn add @omni-network/contracts
+pnpm add @omni-network/contract
+npm install @omni-network/contracts
+```
+
+
+Import (solidity)
+
+
+```solidity
+import {OmniScient} from "@omni-network/contracts/contracts/OmniScient.sol";
+import {OmniCodec} from "@omni-network/contracts/contracts/OmniCodec.sol";
+import {IOmni} from "@omni-network/contracts/contracts/interfaces/IOmni.sol";
+import {IOmniPortal} from "@omni-network/contracts/contracts/interfaces/IOmniPortal.sol";
+```
+
+
+Import (js)
+
+```js
+import {omniABI, omniPortalABI} from "@omni-network/contracts"
+```
+
+
+### forge
+
+
+Install
+
+
+```bash
+forge install github.com/omni-network/omni-std
+```
+
+Import (solidity)
+
+```solidity
+import {OmniScient} from "lib/omni-std/contracts/OmniScient.sol";
+import {OmniCodec} from "lib/omni-std/contracts/OmniCodec.sol";
+import {IOmni} from "lib/omni-std/contracts/interfaces/IOmni.sol";
+import {IOmniPortal} from "lib/omni-std/contracts/interfaces/IOmniPortal.sol";
+```
+
+Or, use [remappings](https://book.getfoundry.sh/projects/dependencies#remapping-dependencies)
+
+
+```toml
+# foundry.toml
+remappings = [
+  "omni-std/=lib/omni-std/contracts",
+]
+```
+
+Update imports
+
+```solidity
+import {OmniScient} from "omni-std/OmniScient.sol";
+import {OmniCodec} from "omni-std/OmniCodec.sol";
+import {IOmni} from "omni-std/interfaces/IOmni.sol";
+import {IOmniPortal} from "omni-std/contracts/interfaces/IOmniPortal.sol";
+```


### PR DESCRIPTION
Addresses https://github.com/omni-network/omni-std/issues/17, though root issue (undesirable import path in hardhat projects) not resolved.  