### PR TITLE
Bumping version to 0.1.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omni-network/contracts",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "packageManager": "yarn@3.5.0",


### PR DESCRIPTION
Version 0.1.4 was published and released with outdated documentation. Documentation was updated later in
https://github.com/omni-network/omni-std/pull/18.
This commit bumps the version number so that a new release can be published with updated docs.

This also resolves discrepency between github and npm pacakage releases. Npm has some 0.1.5-alpha.x pre relases that are not represented on github. We should introduce some "npm publish on github release" flow so that the two do not diverge like this in the future.

-------------------------

Addresses https://github.com/omni-network/omni-std/issues/19